### PR TITLE
fix: prevent ghost header cell when selectableRows is none and expand…

### DIFF
--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -65,7 +65,7 @@ const TableSelectCell = ({
   const CheckboxComponent = components.Checkbox || Checkbox;
   const ExpandButtonComponent = components.ExpandButton || ExpandButton;
 
-  if (expandableOn === false && (selectableOn === 'none' || selectableRowsHideCheckboxes === true)) {
+  if (!expandableOn && (selectableOn === 'none' || selectableRowsHideCheckboxes === true)) {
     return null;
   }
 


### PR DESCRIPTION
…ableRows is unset

**Notes for Reviewers**

This PR fixes #

Before:

<img width="802" height="364" alt="Screenshot 2026-08-30 at 12 55 40 PM" src="https://github.com/user-attachments/assets/964906ff-43b4-4724-a2b7-bb929e982d15" />

After:

<img width="505" height="273" alt="Screenshot 2026-08-30 at 12 56 35 PM" src="https://github.com/user-attachments/assets/53775678-4880-475e-a18a-f2ed42cab2dc" />


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table expansion is now correctly disabled when its configuration is empty or otherwise falsy.
  * Existing behavior for hidden checkboxes and disabled row selection remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->